### PR TITLE
has('gui') → has('gui_running')

### DIFF
--- a/plugin/tabfold.vim
+++ b/plugin/tabfold.vim
@@ -1,6 +1,6 @@
 nnoremap <silent> <s-tab> :<c-U>call tabfold#toggle()<cr>
 
-if has('gui')
+if has('gui_running')
   nnoremap <silent> <tab> :<c-u>call tabfold#toggle<cr>
 else
   nnoremap <silent> <tab> :<c-u>call tabfold#move_forward_or_toggle_fold()<cr>


### PR DESCRIPTION
According to vim/vim#1481, has('gui') only tests whether vim has been compiled with a gui. To test whether the vim instance the plugin is running under is terminal vim or gvim, one must use the has('gui_running') test instead.